### PR TITLE
Fix homepage/source link for the gem

### DIFF
--- a/iso-bib-item.gemspec
+++ b/iso-bib-item.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %(IsoBibItem: Ruby ISOXMLDOC impementation.)
   spec.description   = %(IsoBibItem: Ruby ISOXMLDOC impementation.)
-  spec.homepage      = 'https://github.com/riboseinc/gdbib'
+  spec.homepage      = 'https://github.com/riboseinc/iso-bib-item'
   spec.license       = 'BSD-2-Clause'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
I just came across this gem in rubygems.com, and when I was trying to check the source link from rubygem then it was pointing me to a invalid URL. This commit changes that to the correct URL so our next release will fix the link in rubygems.